### PR TITLE
Subscriber to trigger the emergency stop

### DIFF
--- a/src/gen3_control/include/gen3_control/kortex_robot.h
+++ b/src/gen3_control/include/gen3_control/kortex_robot.h
@@ -80,4 +80,7 @@ public:
     bool updateGripperPosition(double target_position,double proportional_gain=2.0);
     // bool sendVelocity(const Eigen::VectorXd& desired_vel);
     bool setBaseCommand();
+
+    void applyEmergencyStop();
+    void clearEmergencyStop();
 };

--- a/src/gen3_control/src/gen3_vel_control.cpp
+++ b/src/gen3_control/src/gen3_vel_control.cpp
@@ -6,6 +6,7 @@
 #include <trajectory_msgs/msg/joint_trajectory_point.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <std_msgs/msg/float64_multi_array.hpp>
+#include <std_msgs/msg/bool.hpp>
 #include <std_srvs/srv/set_bool.hpp>
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("gen3_control_node");
 std::vector<std::string> joint_names = { "joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6", "joint_7", "robotiq_85_right_knuckle_joint",

--- a/src/gen3_control/src/kortex_robot.cpp
+++ b/src/gen3_control/src/kortex_robot.cpp
@@ -322,3 +322,29 @@ bool kortex_robot::updateGripperPosition(double target_position,double proportio
     }
     return true;
 }
+
+// Stops robot movement and activates emergency stop state.
+void kortex_robot::applyEmergencyStop()
+{
+    try
+    {
+        base->ApplyEmergencyStop(0, {false, 0, 100});
+    }
+    catch (k_api::KDetailedException& ex)
+    {
+        kExceptionHandle(ex);
+    }
+}
+
+// Clears robot stop. Robot is permitted to move again.
+void kortex_robot::clearEmergencyStop()
+{
+    try
+    {
+        base->ClearFaults();
+    }
+    catch (k_api::KDetailedException& ex)
+    {
+        kExceptionHandle(ex);
+    }
+}


### PR DESCRIPTION
I added a subscriber to trigger the emergency stop. Because my code publishes the data, I chose a subscriber instead of a service because it is more convenient. But I guess a service can be added in addition to the subscriber?

The code compiles but **has not been tested** because I don't have the robot. Therefore, I recommend that you test it before accepting the PR.